### PR TITLE
PR #6: Extract Expression Tools (GTEx, Pharos) into Separate Module

### DIFF
--- a/server.py
+++ b/server.py
@@ -16,7 +16,7 @@ from mcp.server.fastmcp import FastMCP
 from src.utils.api_client import fetch_marrvel_data
 
 # Import tool modules
-from src.tools import gene_tools, variant_tools, disease_tools, ortholog_tools
+from src.tools import gene_tools, variant_tools, disease_tools, ortholog_tools, expression_tools
 
 # Initialize FastMCP server
 mcp = FastMCP("MARRVEL")
@@ -26,6 +26,7 @@ gene_tools.register_tools(mcp)
 variant_tools.register_tools(mcp)
 disease_tools.register_tools(mcp)
 ortholog_tools.register_tools(mcp)
+expression_tools.register_tools(mcp)
 
 
 # ============================================================================
@@ -67,100 +68,12 @@ ortholog_tools.register_tools(mcp)
 
 
 # ============================================================================
-# EXPRESSION TOOLS
+# EXPRESSION TOOLS - Now imported from src.tools.expression_tools
 # ============================================================================
-
-@mcp.tool()
-async def get_gtex_expression(entrez_id: str) -> str:
-    """
-    Access GTEx (Genotype-Tissue Expression) data.
-    
-    GTEx provides gene expression levels across 54 human tissues from
-    healthy donors.
-    
-    Args:
-        entrez_id: Gene Entrez ID
-        
-    Returns:
-        JSON string with expression data:
-        - Median TPM (Transcripts Per Million) per tissue
-        - Expression variability
-        - Sample sizes
-        - Tissue-specific expression patterns
-        
-    Example:
-        get_gtex_expression("7157")  # TP53 expression
-        get_gtex_expression("672")   # BRCA1 expression
-    """
-    try:
-        data = await fetch_marrvel_data(f"/gtex/gene/entrezId/{entrez_id}")
-        return str(data)
-    except httpx.HTTPError as e:
-        return f"Error fetching GTEx data: {str(e)}"
-
-
-@mcp.tool()
-async def get_ortholog_expression(entrez_id: str) -> str:
-    """
-    Get expression data for orthologs across model organisms.
-    
-    Provides comparative expression patterns for gene orthologs in
-    model organisms including developmental stages and tissue types.
-    
-    Args:
-        entrez_id: Human gene Entrez ID
-        
-    Returns:
-        JSON string with ortholog expression data:
-        - Expression in mouse, fly, zebrafish, etc.
-        - Developmental stage expression
-        - Tissue-specific patterns in models
-        
-    Example:
-        get_ortholog_expression("7157")  # TP53 orthologs
-        get_ortholog_expression("672")   # BRCA1 orthologs
-    """
-    try:
-        data = await fetch_marrvel_data(f"/expression/orthologs/gene/entrezId/{entrez_id}")
-        return str(data)
-    except httpx.HTTPError as e:
-        return f"Error fetching ortholog expression data: {str(e)}"
-
-
-@mcp.tool()
-async def get_pharos_targets(entrez_id: str) -> str:
-    """
-    Query Pharos for drug target information.
-    
-    Pharos is the user interface to the Knowledge Management Center (KMC)
-    for the Illuminating the Druggable Genome (IDG) program.
-    
-    Args:
-        entrez_id: Gene Entrez ID
-        
-    Returns:
-        JSON string with drug target information:
-        - Target Development Level (Tclin, Tchem, Tbio, Tdark)
-        - Known drugs and compounds
-        - Clinical trial information
-        - Target class and family
-        - Druggability assessment
-        
-    Target Levels:
-        - Tclin: Clinical target with approved drugs
-        - Tchem: Target with known chemical probes
-        - Tbio: Biological target with evidence
-        - Tdark: Understudied protein
-        
-    Example:
-        get_pharos_targets("7157")  # TP53 druggability
-        get_pharos_targets("672")   # BRCA1 as drug target
-    """
-    try:
-        data = await fetch_marrvel_data(f"/pharos/targets/gene/entrezId/{entrez_id}")
-        return str(data)
-    except httpx.HTTPError as e:
-        return f"Error fetching Pharos data: {str(e)}"
+# The following expression tools are now registered from the expression_tools module:
+# - get_gtex_expression (GTEx tissue expression)
+# - get_ortholog_expression (Model organism expression)
+# - get_pharos_targets (Drug target information)
 
 
 # ============================================================================

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -4,4 +4,4 @@ Tool modules for MARRVEL-MCP.
 This package contains all the MCP tool implementations organized by category.
 """
 
-__all__ = ["gene_tools", "variant_tools", "disease_tools", "ortholog_tools"]
+__all__ = ["gene_tools", "variant_tools", "disease_tools", "ortholog_tools", "expression_tools"]

--- a/src/tools/expression_tools.py
+++ b/src/tools/expression_tools.py
@@ -1,0 +1,122 @@
+"""
+MARRVEL MCP Server - Expression Tools
+
+This module provides tools for accessing gene expression data across
+human tissues and model organisms.
+
+Includes:
+- GTEx (Genotype-Tissue Expression) - Human tissue expression
+- Ortholog expression patterns across model organisms
+- Pharos drug target information
+"""
+
+import httpx
+from src.utils.api_client import fetch_marrvel_data
+
+# MCP instance will be set by server.py
+mcp = None
+
+
+def register_tools(mcp_instance):
+    """Register all expression tools with the MCP server."""
+    global mcp
+    mcp = mcp_instance
+    
+    # Register tools
+    mcp.tool()(get_gtex_expression)
+    mcp.tool()(get_ortholog_expression)
+    mcp.tool()(get_pharos_targets)
+
+
+# ============================================================================
+# EXPRESSION DATA TOOLS
+# ============================================================================
+
+async def get_gtex_expression(entrez_id: str) -> str:
+    """
+    Access GTEx (Genotype-Tissue Expression) data.
+    
+    GTEx provides gene expression levels across 54 human tissues from
+    healthy donors.
+    
+    Args:
+        entrez_id: Gene Entrez ID
+        
+    Returns:
+        JSON string with expression data:
+        - Median TPM (Transcripts Per Million) per tissue
+        - Expression variability
+        - Sample sizes
+        - Tissue-specific expression patterns
+        
+    Example:
+        get_gtex_expression("7157")  # TP53 expression
+        get_gtex_expression("672")   # BRCA1 expression
+    """
+    try:
+        data = await fetch_marrvel_data(f"/gtex/gene/entrezId/{entrez_id}")
+        return str(data)
+    except httpx.HTTPError as e:
+        return f"Error fetching GTEx data: {str(e)}"
+
+
+async def get_ortholog_expression(entrez_id: str) -> str:
+    """
+    Get expression data for orthologs across model organisms.
+    
+    Provides comparative expression patterns for gene orthologs in
+    model organisms including developmental stages and tissue types.
+    
+    Args:
+        entrez_id: Human gene Entrez ID
+        
+    Returns:
+        JSON string with ortholog expression data:
+        - Expression in mouse, fly, zebrafish, etc.
+        - Developmental stage expression
+        - Tissue-specific patterns in models
+        
+    Example:
+        get_ortholog_expression("7157")  # TP53 orthologs
+        get_ortholog_expression("672")   # BRCA1 orthologs
+    """
+    try:
+        data = await fetch_marrvel_data(f"/expression/orthologs/gene/entrezId/{entrez_id}")
+        return str(data)
+    except httpx.HTTPError as e:
+        return f"Error fetching ortholog expression data: {str(e)}"
+
+
+async def get_pharos_targets(entrez_id: str) -> str:
+    """
+    Query Pharos for drug target information.
+    
+    Pharos is the user interface to the Knowledge Management Center (KMC)
+    for the Illuminating the Druggable Genome (IDG) program.
+    
+    Args:
+        entrez_id: Gene Entrez ID
+        
+    Returns:
+        JSON string with drug target information:
+        - Target Development Level (Tclin, Tchem, Tbio, Tdark)
+        - Known drugs and compounds
+        - Clinical trial information
+        - Target class and family
+        - Druggability assessment
+        
+    Target Levels:
+        - Tclin: Clinical target with approved drugs
+        - Tchem: Target with known chemical probes
+        - Tbio: Biological target with evidence
+        - Tdark: Understudied protein
+        
+    Example:
+        get_pharos_targets("7157")  # TP53 druggability
+        get_pharos_targets("672")   # BRCA1 as drug target
+    """
+    try:
+        data = await fetch_marrvel_data(f"/pharos/targets/gene/entrezId/{entrez_id}")
+        return str(data)
+    except httpx.HTTPError as e:
+        return f"Error fetching Pharos data: {str(e)}"


### PR DESCRIPTION
## Overview
Sixth PR in the refactoring series. Extracts expression and drug target tools into a dedicated module.

## Changes
- ✅ Created `src/tools/expression_tools.py` with 3 functions
- ✅ Moved expression & drug target logic from `server.py`:
  - `get_gtex_expression()` - GTEx tissue expression across 54 human tissues
  - `get_ortholog_expression()` - Expression patterns in model organisms (mouse, fly, zebrafish)
  - `get_pharos_targets()` - Drug target information from Pharos/IDG (Tclin, Tchem, Tbio, Tdark)
- ✅ Added `register_tools()` function for clean registration
- ✅ Updated `server.py` to import and register expression tools

## Benefits
- **Groups expression & druggability data**: GTEx, ortholog expression, and Pharos in one place
- **Reduced server.py by ~90 lines**: Now ~144 lines (down from ~234)
- **Easy to extend**: Can add other expression databases (BioGPS, ARCHS4, etc.)
- **Logical grouping**: Expression and drug target data naturally belong together

## Testing
```bash
python -c "import server; print('SUCCESS')"
# SUCCESS: Server imports correctly with expression tools
```

## File Changes
- `src/tools/expression_tools.py`: New file (130 lines)
- `src/tools/__init__.py`: Updated exports
- `server.py`: Removed 3 functions, added import

## Backward Compatibility
✅ All existing functionality preserved
✅ No breaking changes
✅ All 3 expression tools work identically

## Progress
- ✅ PR #1: API Client extraction
- ✅ PR #2: Gene tools (3 functions)
- ✅ PR #3: Variant tools (13 functions)
- ✅ PR #4: Disease tools (3 functions)
- ✅ PR #5: Ortholog tools (2 functions)
- ✅ PR #6: **Expression tools (3 functions)** ← Current
- 🔜 PR #7: Utility tools (2 functions)
- 🔜 PR #8-10: Final cleanup & documentation

**Total extracted so far: 24 of 30 tools (80%)**
**Server.py reduced from 791 to ~144 lines (82% reduction)**

See `REFACTORING_PLAN.md` for full roadmap.