### PR TITLE
Fix legacy test imports after modular refactoring

### DIFF
--- a/tests/test_api_direct.py
+++ b/tests/test_api_direct.py
@@ -11,8 +11,9 @@ import pytest
 
 sys.path.insert(0, '/Users/hyun-hwanjeong/Workspaces/MARRVEL_MCP')
 
-# Import the fetch function and BASE_URL directly
-from server import fetch_marrvel_data, BASE_URL
+# Import the fetch function and BASE_URL from their new locations
+from src.utils.api_client import fetch_marrvel_data
+from config import API_BASE_URL as BASE_URL
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -7,16 +7,15 @@ Claude Desktop. Useful for testing with OpenAI or other LLM integrations.
 
 import asyncio
 import pytest
-from server import (
-    get_gene_by_entrez_id,
-    get_gene_by_symbol,
+from src.tools.gene_tools import get_gene_by_entrez_id, get_gene_by_symbol
+from src.tools.variant_tools import (
     get_variant_dbnsfp,
     get_clinvar_by_variant,
-    get_gnomad_variant,
-    get_omim_by_gene_symbol,
-    get_diopt_orthologs,
-    get_gtex_expression
+    get_gnomad_variant
 )
+from src.tools.disease_tools import get_omim_by_gene_symbol
+from src.tools.ortholog_tools import get_diopt_orthologs
+from src.tools.expression_tools import get_gtex_expression
 
 
 @pytest.mark.asyncio

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -12,10 +12,8 @@ import os
 # Add parent directory to path to import server
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from server import (
-    fetch_marrvel_data,
-    BASE_URL
-)
+from src.utils.api_client import fetch_marrvel_data
+from config import API_BASE_URL as BASE_URL
 
 
 class TestFetchMarrvelData:


### PR DESCRIPTION
## Summary
This PR fixes import errors in three legacy test files that broke after the modular refactoring (PRs #1-8).

## Changes
- **test_api_direct.py**: Updated imports from `server` to `src.utils.api_client` and `config`
- **test_mcp_client.py**: Updated imports from `server` to respective `src.tools` modules (gene_tools, variant_tools, disease_tools, ortholog_tools, expression_tools)
- **test_server.py**: Updated imports from `server` to `src.utils.api_client` and `config`

## Testing
Comprehensive test suite run:
- **164 out of 165 tests passing** ✅
- 1 failure is unrelated to imports (API issue with `get_gene_by_position`)

All import errors resolved successfully.

Fixes #27