### PR TITLE
Add Server Integration Test Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,24 +245,25 @@ pytest tests/ -m "not integration"
 # Run direct API tests
 python3 tests/test_api_direct.py
 
-# Run server integration test (full lifecycle)
+# Run server integration tests
+pytest tests/test_server_integration.py -v -m integration
+
+# Or run as standalone script
 python tests/test_server_integration.py
 ```
 
-#### Server Integration Test
+#### Server Integration Tests
 
-The `test_server_integration.py` script tests the complete MCP server lifecycle:
+The `test_server_integration.py` contains pytest-based integration tests for the complete MCP server lifecycle:
 
-1. ✅ Start the server
-2. ✅ Send JSON-RPC requests (initialize, list tools, call tool)
-3. ✅ Verify JSON responses
-4. ✅ Gracefully shut down the server
+- ✅ `test_server_starts` - Verify server process starts
+- ✅ `test_server_initialize` - Test JSON-RPC initialization
+- ✅ `test_server_list_tools` - Test tools/list request
+- ✅ `test_server_call_tool` - Test calling get_gene_info
+- ✅ `test_server_graceful_shutdown` - Test clean shutdown
+- ✅ `test_server_protocol_compliance` - Verify JSON-RPC 2.0 compliance
 
-This is useful for:
-
-- Verifying server functionality end-to-end
-- Testing before deployment
-- Debugging server communication issues
+These tests use pytest fixtures for automatic setup/teardown and can be integrated into CI/CD pipelines.
 
 ### OpenAI Integration
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -29,12 +29,13 @@ This directory contains all test files for the MARRVEL-MCP project.
 
 ### Server Integration Testing
 
-- **`test_server_integration.py`** - Full server lifecycle test
-  - Tests complete MCP server operations end-to-end
-  - Starts server, sends requests, verifies responses, shuts down
-  - Validates JSON-RPC protocol compliance
-  - Tests initialize, tools/list, and tools/call operations
-  - Run: `python tests/test_server_integration.py`
+- **`test_server_integration.py`** - Pytest-based server lifecycle tests
+  - 6 integration tests covering complete MCP server operations
+  - Uses pytest fixtures for automatic server setup/teardown
+  - Tests: server start, initialize, list tools, call tool, shutdown, protocol compliance
+  - Validates JSON-RPC 2.0 protocol compliance
+  - Run with pytest: `pytest tests/test_server_integration.py -v -m integration`
+  - Run standalone: `python tests/test_server_integration.py`
 
 ## Running Tests
 


### PR DESCRIPTION
## Description
Implements comprehensive **pytest-based** integration tests for MARRVEL-MCP server operations as described in Issue #36.

## Changes
- ✅ **New Pytest Test Module**: `tests/test_server_integration.py`
  - 6 separate test functions covering complete server lifecycle
  - Uses pytest fixture (`mcp_server`) for automatic setup/teardown
  - Tests marked with `@pytest.mark.integration` for selective running
  - Validates JSON-RPC 2.0 protocol compliance
  - Can run with pytest or as standalone script

- ✅ **Test Coverage**:
  - `test_server_starts` - Server process initialization
  - `test_server_initialize` - JSON-RPC initialize request
  - `test_server_list_tools` - tools/list operation
  - `test_server_call_tool` - Calling get_gene_info tool
  - `test_server_graceful_shutdown` - Clean shutdown
  - `test_server_protocol_compliance` - JSON-RPC 2.0 validation

- ✅ **Documentation Updates**:
  - Updated `README.md` with pytest command examples
  - Updated `tests/README.md` with test descriptions
  - Added test to project structure documentation

## Test Results
```
======================== test session starts =========================
tests/test_server_integration.py::test_server_starts PASSED     [ 16%]
tests/test_server_integration.py::test_server_initialize PASSED [ 33%]
tests/test_server_integration.py::test_server_list_tools PASSED [ 50%]
tests/test_server_integration.py::test_server_call_tool PASSED  [ 66%]
tests/test_server_integration.py::test_server_graceful_shutdown PASSED [ 83%]
tests/test_server_integration.py::test_server_protocol_compliance PASSED [100%]

======================== 6 passed in 12.15s ==========================
```

## Usage

### With pytest (recommended):
```bash
# Run integration tests
pytest tests/test_server_integration.py -v -m integration

# Run with all tests
pytest tests/

# Skip integration tests
pytest tests/ -m "not integration"
```

### Standalone:
```bash
python tests/test_server_integration.py
```

## Technical Details
- **Pytest fixtures** for server lifecycle management
- **Automatic cleanup** via fixture teardown
- **Integration marker** for selective test execution
- stdio communication (MCP protocol standard)
- 10-second timeout for operations
- Type hints with Python 3.10+ union syntax (`dict | None`)
- Proper error handling with `pytest.fail()`
- Works with virtual environment Python

## Benefits
- ✅ Integrates with existing pytest test suite
- ✅ Automatic setup/teardown - no manual cleanup needed
- ✅ Can be included in CI/CD pipelines
- ✅ Selective execution with markers
- ✅ Better error reporting with pytest
- ✅ Reusable `mcp_server` fixture for future tests

## Related
- Closes #36
- Part of testing infrastructure improvements
- Complements existing unit tests
- Uses same `@pytest.mark.integration` pattern as other integration tests

## Testing
- ✅ Tested on macOS with Python 3.13.7
- ✅ Pre-commit hooks passed
- ✅ All 6 tests passing
- ✅ Server starts, responds, and shuts down correctly
- ✅ Works both with pytest and standalone execution