### PR TITLE
fix(gtex): canonicalize GTEx endpoint in integration capture test (fixes #71)

### DIFF
--- a/tests/integration/api/test_api_capture_example.py
+++ b/tests/integration/api/test_api_capture_example.py
@@ -214,9 +214,9 @@ async def test_diopt_api_with_capture(api_capture):
 @pytest.mark.asyncio
 async def test_expression_api_with_capture(api_capture):
     """Test GTEx expression API endpoint and capture the response."""
-    # Test expression data
-    gene_symbol = "TP53"
-    endpoint = f"/gtex/{gene_symbol}"
+    # Test expression data (use canonical entrezId endpoint)
+    entrez_id = "7157"
+    endpoint = f"/gtex/gene/entrezId/{entrez_id}"
 
     try:
         result = await fetch_marrvel_data(endpoint)
@@ -232,7 +232,7 @@ async def test_expression_api_with_capture(api_capture):
         api_capture.log_response(
             tool_name="get_gtex_expression",
             endpoint=endpoint,
-            input_data={"gene_symbol": gene_symbol},
+            input_data={"entrez_id": entrez_id},
             output_data=result,
             status="success",
             return_code=return_code,
@@ -249,7 +249,7 @@ async def test_expression_api_with_capture(api_capture):
         api_capture.log_response(
             tool_name="get_gtex_expression",
             endpoint=endpoint,
-            input_data={"gene_symbol": gene_symbol},
+            input_data={"entrez_id": entrez_id},
             output_data=None,
             status="error",
             error=str(e),


### PR DESCRIPTION
This PR updates the GTEx integration capture test to use the canonical endpoint `/gtex/gene/entrezId/{entrez_id}` (previously `/gtex/{symbol}`) so tests, tools, and documentation are consistent.

Why:
- `src/tools/expression_tools.get_gtex_expression` and docs expect `/gtex/gene/entrezId/:id`.
- The test previously used `/gtex/{symbol}`, which caused an endpoint mismatch referenced in issue #71.

What changed:
- `tests/integration/api/test_api_capture_example.py` now calls `/gtex/gene/entrezId/7157` and logs `entrez_id` as input.

Verification performed:
- Ran GTEx unit tests (`tests/unit/test_expression_tools.py`) — passed.
- Ran the GTEx integration capture test file (`tests/integration/api/test_api_capture_example.py`) — passed locally (5 tests).

This closes hyunhwan-bcm/MARRVEL_MCP#71.

Requesting review from the maintainers.