### PR TITLE
fix(variant): dbNSFP variant format + encode endpoint in integration test (fixes #76)

### DIFF
--- a/src/tools/variant_tools.py
+++ b/src/tools/variant_tools.py
@@ -51,9 +51,9 @@ async def get_variant_dbnsfp(variant: str) -> str:
     SIFT, PolyPhen2, CADD scores, conservation scores, and population frequencies.
 
     Args:
-        variant: Variant in format "chromosome-position-reference-alternate"
+        variant: Variant in canonical format "chromosome:position reference>alternate"
                  Uses hg19/GRCh37 coordinates
-                 Example: "17-7577121-C-T"
+                 Example: "17:7577121 C>T"
 
     Returns:
         JSON string with extensive variant annotations:
@@ -64,8 +64,8 @@ async def get_variant_dbnsfp(variant: str) -> str:
         - Gene and protein information
 
     Example:
-        get_variant_dbnsfp("17-7577121-C-T")  # TP53 variant
-        get_variant_dbnsfp("13-32900000-G-A")  # BRCA2 region
+        get_variant_dbnsfp("17:7577121 C>T")  # TP53 variant
+        get_variant_dbnsfp("13:32900000 G>A")  # BRCA2 region
     """
     try:
         data = await fetch_marrvel_data(f"/dbnsfp/variant/{variant}")

--- a/tests/integration/api/test_api_capture_example.py
+++ b/tests/integration/api/test_api_capture_example.py
@@ -8,6 +8,7 @@ API responses during test execution.
 import sys
 import os
 import pytest
+from urllib.parse import quote
 
 # Add project root to Python path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))))
@@ -69,9 +70,11 @@ async def test_gene_api_with_capture(api_capture):
 @pytest.mark.asyncio
 async def test_variant_api_with_capture(api_capture):
     """Test variant API endpoint and capture the response."""
-    # Test variant
-    variant = "17-7577121-C-T"
-    endpoint = f"/variant/dbnsfp/{variant}"
+    # Test variant (use canonical format and endpoint)
+    variant = "6:99365567 T>C"
+    # Preserve ':' but encode spaces and special chars (like '>') to avoid breaking markdown tables
+    encoded_variant = quote(variant, safe=":")
+    endpoint = f"/dbnsfp/variant/{encoded_variant}"
 
     try:
         result = await fetch_marrvel_data(endpoint)


### PR DESCRIPTION
This PR fixes the variant integration capture test and updates the variant tool docs:

- `src/tools/variant_tools.py`: document canonical variant format as `chromosome:position ref>alt` (e.g., `17:7577121 C>T`).
- `tests/integration/api/test_api_capture_example.py`: use example variant `6:99365567 T>C` and URL-encode the variant in the endpoint (preserves `:` but encodes spaces/`>`), so markdown tables don't break and the endpoint is safe.

This resolves issue #76 where the test received an HTML response due to a malformed endpoint with spaces.

Validation:
- Ran the integration test file locally; all tests passed.

Closes #76.