### PR TITLE
Add liftover tool and integration test (isolated branch)

### DIFF
--- a/docs/API_CAPTURE_FLOW.md
+++ b/docs/API_CAPTURE_FLOW.md
@@ -9,7 +9,7 @@
                               │
                               ▼
 ┌─────────────────────────────────────────────────────────────────┐
-│  1. Write Integration Test with api_capture Fixture            │
+│  1. Write Integration Test with api_capture Fixture             │
 │                                                                 │
 │     @pytest.mark.integration_api                                │
 │     async def test_my_api(api_capture):                         │


### PR DESCRIPTION
This PR adds the liftover tool for genome coordinate conversion (hg38 <-> hg19) and an integration test, isolated on its own branch.

- Implements liftover tools in `src/tools/liftover_tools.py` for both hg38->hg19 and hg19->hg38
- Adds integration test in `tests/integration/mcp/test_liftover_tools.py` (calls real MARRVEL API)
- References Issue #93

This branch is independent of the MCP tools smoke test PR.