### PR TITLE
feat: Update liftover tools to return raw data instead of JSON string…

### DIFF
--- a/src/tools/liftover_tools.py
+++ b/src/tools/liftover_tools.py
@@ -39,7 +39,7 @@ async def liftover_hg38_to_hg19(chr: str, pos: int) -> str:
     try:
         endpoint = f"/data/liftover/hg38/chr/{chr}/pos/{pos}/hg19"
         data = await fetch_marrvel_data(endpoint)
-        return json.dumps(data, indent=2)
+        return data
     except httpx.HTTPError as e:
         return json.dumps({"error": f"Error fetching liftover data: {str(e)}"})
 
@@ -64,6 +64,6 @@ async def liftover_hg19_to_hg38(chr: str, pos: int) -> str:
     try:
         endpoint = f"/data/liftover/hg19/chr/{chr}/pos/{pos}/hg38"
         data = await fetch_marrvel_data(endpoint)
-        return json.dumps(data, indent=2)
+        return data
     except httpx.HTTPError as e:
         return json.dumps({"error": f"Error fetching liftover data: {str(e)}"})


### PR DESCRIPTION
This pull request simplifies the handling and parsing of tool responses, particularly for the liftover tools, and streamlines the related integration tests. The changes remove redundant parsing logic, ensure consistent response formats, and improve error reporting in the test suite.

**API and Response Handling Improvements:**

* The `liftover_hg38_to_hg19` and `liftover_hg19_to_hg38` functions in `liftover_tools.py` now directly return the fetched data instead of serializing it to JSON, making the response format more predictable for consumers. 
* The `_maybe_await` function in `api_client.py` is simplified to remove complex fallback parsing and always returns JSON-serialized data or a clear error message, with improved error diagnostics including content type.

**Test Suite Simplification and Robustness:**

* The integration test `test_tool_returns_json_or_fail` is streamlined: it now directly extracts the result from the tool response, removes custom parsing and unwrapping helpers, and fails the test on exceptions instead of skipping, ensuring issues are surfaced promptly.
* The test helper functions `try_parse_text` and `_unwrap_if_necessary`, which contained complex logic for parsing various response formats, are removed, reflecting the more consistent API response structure.
* Test output is now written as a raw string instead of using `json.dump`, aligning with the new response format and preventing double-serialization.…s and simplify error handling in API client