### PR TITLE
converted get_diopt_orthologs_by_entrez_id to graphql

### DIFF
--- a/server.py
+++ b/server.py
@@ -780,10 +780,12 @@ async def get_diopt_orthologs_by_entrez_id(entrez_id: str) -> str:
                     taxonId2
                 }}
             }}
-            """)
+            """
+        )
         return data
     except httpx.HTTPError as e:
         return f"Error fetching DIOPT data: {str(e)}"
+
 
 @mcp.tool(
     name="get_diopt_alignment",


### PR DESCRIPTION
Implemented get_diopt_orthologs_by_entrez_id in graphql.

Returns taxon id, entrez gene id, and quality metrics for each diopt ortholog. Does not return information about "gene1" since this information is provided in the query itself.