### PR TITLE
fix: Add dual API support for GraphQL and REST endpoints

### DIFF
--- a/server.py
+++ b/server.py
@@ -509,7 +509,7 @@ async def get_gnomad_by_gene_symbol(gene_symbol: str) -> str:
 )
 async def get_gnomad_by_entrez_id(entrez_id: str) -> str:
     try:
-        data = await fetch_marrvel_data(f"/gnomad/gene/entrezId/{entrez_id}", is_graphql=False)
+        data = await fetch_marrvel_data(f"/gnomAD/gene/entrezId/{entrez_id}", is_graphql=False)
         return data
     except Exception as e:
         return json.dumps({"error": f"Failed to fetch data: {str(e)}"})


### PR DESCRIPTION
- Updated fetch_marrvel_data() to support both GraphQL (POST) and REST (GET) requests
- Added is_graphql parameter (default: True) to distinguish between API types
- Separated API_BASE_URL (GraphQL) and API_REST_BASE_URL (REST) configurations
- Updated all REST endpoint calls to use `is_graphql=False` parameter
- Maintained backward compatibility with existing GraphQL queries
- Fixed broken REST API calls by using proper async httpx client

This migration fix ensures proper handling of both API endpoints:
- GraphQL queries use POST to https://marrvel.org/graphql
- REST endpoints use GET to https://marrvel.org/data/