### PR TITLE
implemented get_clinvar_by_variant and get_clinvar_by_symbol in graphql

### DIFF
--- a/server.py
+++ b/server.py
@@ -283,6 +283,7 @@ async def get_gene_by_symbol(gene_symbol: str, taxon_id: str = "9606") -> str:
                     alias
                     chr
                     entrezId
+                    hg38Start
                     hg38Stop
                     hgncId
                     uniprotKBId
@@ -291,7 +292,6 @@ async def get_gene_by_symbol(gene_symbol: str, taxon_id: str = "9606") -> str:
                     status
                     name
                     locusType
-                    hg38Start
                     xref {{
                         ensemblId
                         hgncId


### PR DESCRIPTION
Get_clinvar_by_gene_symbol is nearly identical to the previous PR (get_clinvar_by_entrez_id).
Get_clinvar_by_variant includes more details than the other two because a) we don't need to return any loci information since that is part of the query and b) this will only return one entry at a time. As such it returns all info not related to info provided in the query.