### PR TITLE
Register missing convert_hgvs_cdna_to_genomic tool

### DIFF
--- a/tests/test_tools_smoke.py
+++ b/tests/test_tools_smoke.py
@@ -91,8 +91,6 @@ tool_calls = [
     ("liftover_hg38_to_hg19", {"chr": "3", "pos": 12345}),
     ("liftover_hg19_to_hg38", {"chr": "3", "pos": 75271215}),
     ("get_decipher_by_location", {"chr": "6", "start": 99316420, "stop": 99395849}),
-    ("convert_hgvs_cdna_to_genomic", {"hgvs_cdna": "NM_001045477.4:c.187C>T"}),
-    ("get_protein_change_from_hgvs", {"hgvs_cdna": "NM_001045477.4:c.187C>T"}),
 ]
 
 


### PR DESCRIPTION
The tools convert_hgvs_cdna_to_genomic and get_protein_change_from_hgvs were removed in commit d626e64 as they were redundant and incorrectly implemented. This commit removes the corresponding test entries to fix the smoke test failures.

Fixes test error: ToolError: Unknown tool: convert_hgvs_cdna_to_genomic