### PR TITLE
Add output truncation with copy button

### DIFF
--- a/assets/evaluation_report_template.html
+++ b/assets/evaluation_report_template.html
@@ -137,20 +137,20 @@ Template variables: success_rate, successful_tests, total_tests, results (list o
                             <td class="px-4 py-3 text-sm">{{ result.expected }}</td>
                             <td class="px-4 py-3 text-sm">
                                 {% set max_length = 1000 %}
-                                {% if result.response|length > max_length %}
                                 <div class="mb-2">
+                                    {% if result.response|length > max_length %}
                                     <span id="response-truncated-{{ result.idx }}">{{ result.response[:max_length] }}...</span>
+                                    {% else %}
+                                    <span id="response-truncated-{{ result.idx }}">{{ result.response }}</span>
+                                    {% endif %}
                                     <span id="response-full-{{ result.idx }}" class="hidden">{{ result.response }}</span>
-                                    <button id="response-copy-btn-{{ result.idx }}" onclick="copyResponseToClipboard({{ result.idx }})" class="ml-2 inline-flex items-center px-2 py-1 bg-gray-500 hover:bg-gray-600 text-white text-xs rounded transition-colors" title="Copy full response to clipboard">
+                                    <button id="response-copy-btn-{{ result.idx }}" onclick="copyResponseToClipboard({{ result.idx }})" class="ml-2 inline-flex items-center px-2 py-1 bg-gray-500 hover:bg-gray-600 text-white text-xs rounded transition-colors" title="Copy response to clipboard">
                                         <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
                                             <path d="M8 2a1 1 0 000 2h2a1 1 0 100-2H8z" />
                                             <path d="M3 5a2 2 0 012-2 3 3 0 003 3h2a3 3 0 003-3 2 2 0 012 2v6h-4.586l1.293-1.293a1 1 0 00-1.414-1.414l-3 3a1 1 0 000 1.414l3 3a1 1 0 001.414-1.414L10.414 13H15v3a2 2 0 01-2 2H5a2 2 0 01-2-2V5zM15 11h2a1 1 0 110 2h-2v-2z" />
                                         </svg>
                                     </button>
                                 </div>
-                                {% else %}
-                                <div class="mb-2">{{ result.response }}</div>
-                                {% endif %}
                                 <button onclick="openModal({{ result.idx }})" class="mt-2 text-blue-600 hover:text-blue-800 text-xs font-medium underline cursor-pointer">
                                     View Full Conversation JSON
                                 </button>


### PR DESCRIPTION
- Truncate responses longer than 1000 characters
- Add '...' indicator for truncated content
- Add clipboard button to copy full response
- Visual feedback with green checkmark on successful copy