### PR TITLE
Apply concurrency across all runs for dramatic speedup

### DIFF
--- a/assets/evaluation_report_template.html
+++ b/assets/evaluation_report_template.html
@@ -283,7 +283,6 @@ Template variables: success_rate, successful_tests, total_tests, results (list o
                                     <button id="copy-btn-{{ result.idx }}-{{ model_id|replace('/', '_')|replace('.', '_') }}-web" onclick="copyToClipboard('{{ result.idx }}-{{ model_id|replace('/', '_')|replace('.', '_') }}-web')" class="inline-flex items-center gap-x-2 px-4 py-2 bg-gray-600 text-white text-sm font-medium rounded-md hover:bg-gray-700">
                                         Copy JSON
                                     </button>
-                                    {% endif %}
                                     <button onclick="closeModal('{{ result.idx }}-{{ model_id|replace('/', '_')|replace('.', '_') }}-web')" class="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-md hover:bg-blue-700">
                                         Close
                                     </button>


### PR DESCRIPTION
This commit refactors the multi-model testing mode to run ALL tasks concurrently instead of sequentially, resulting in significant performance improvements (up to 9x faster for 3 models × 3 modes).

Key changes:
1. Refactored get_langchain_response() to accept llm instances as parameters instead of using global variables
2. Refactored evaluate_response() to accept llm instance parameter
3. Updated run_test_case() to pass llm instances to both functions
4. Completely rewrote multi-model loop to create ALL tasks upfront (all models × all modes × all test cases) and execute them concurrently

Before: Models ran sequentially, modes ran sequentially within each model,
        only test cases within a mode ran concurrently
After:  ALL tasks (models × modes × tests) run concurrently with shared
        semaphore controlling overall concurrency limit

The global llm variable swapping was the main bottleneck preventing parallelization across models. Now each task gets its own llm instance.

Maintains backward compatibility by falling back to global llm variables when instances are not provided.