### PR TITLE
Add evaluation model and provider information to test reports

### DIFF
--- a/assets/evaluation_report_template.html
+++ b/assets/evaluation_report_template.html
@@ -162,6 +162,14 @@ Template variables: success_rate, successful_tests, total_tests, results (list o
             <div class="bg-gradient-to-r from-blue-600 to-indigo-700 px-6 py-8">
                 <h1 class="text-3xl font-bold text-white">Evaluation Results</h1>
                 <p class="text-blue-100 mt-2">MCP Test Case Evaluation Summary</p>
+                {% if evaluator_model %}
+                <div class="mt-3 bg-white bg-opacity-10 rounded px-3 py-1.5 inline-block">
+                    <p class="text-blue-100 text-xs">
+                        <span class="font-semibold">Evaluator:</span> {{ evaluator_model }}
+                        {% if evaluator_provider %} ({{ evaluator_provider }}){% endif %}
+                    </p>
+                </div>
+                {% endif %}
 
                 <!-- Success Rate Summary -->
                 {% if multi_model %}
@@ -170,7 +178,8 @@ Template variables: success_rate, successful_tests, total_tests, results (list o
                     <div class="grid gap-4" style="grid-template-columns: repeat({{ models_stats|length }}, minmax(200px, 1fr));">
                         {% for model_id, stats in models_stats.items() %}
                         <div class="border-r border-blue-300 border-opacity-30 pr-4 last:border-r-0">
-                            <p class="text-white text-sm font-semibold mb-2">{{ stats.name }}</p>
+                            <p class="text-white text-sm font-semibold mb-1">{{ stats.name }}</p>
+                            <p class="text-blue-200 text-xs mb-2">({{ stats.provider }})</p>
                             <div class="space-y-2">
                                 <div>
                                     <p class="text-blue-100 text-xs">🍦 Vanilla: {{ "%.1f"|format(stats.vanilla_rate) }}%</p>
@@ -274,7 +283,10 @@ Template variables: success_rate, successful_tests, total_tests, results (list o
                             <th class="px-4 py-3 text-left text-xs font-bold text-gray-700 uppercase tracking-wider" rowspan="2">Question</th>
                             <th class="px-4 py-3 text-left text-xs font-bold text-gray-700 uppercase tracking-wider" rowspan="2">Expected</th>
                             {% for model_id, stats in models_stats.items() %}
-                            <th class="px-2 py-3 text-center text-xs font-bold text-gray-700 uppercase tracking-wider border-l-2 border-gray-400" colspan="3">{{ stats.name }}</th>
+                            <th class="px-2 py-3 text-center text-xs font-bold text-gray-700 border-l-2 border-gray-400" colspan="3">
+                                <div>{{ stats.name }}</div>
+                                <div class="text-xs font-normal text-gray-500 mt-0.5">({{ stats.provider }})</div>
+                            </th>
                             {% endfor %}
                         </tr>
                         <!-- Mode names row -->


### PR DESCRIPTION
## Summary
- Display the evaluation model and provider used for grading test responses
- Show provider information for each tested model in multi-model comparisons

## Changes Made

### evaluate_mcp.py
- Added `evaluator_model` and `evaluator_provider` parameters to `generate_html_report()`
- Updated multi-model results structure to include provider information for each tested model
- Updated all `generate_html_report()` calls to pass evaluator model and provider info

### evaluation_report_template.html
- Added evaluator info badge in the header showing which model/provider graded the responses
- Updated multi-model summary cards to display provider under each model name
- Updated table headers to show provider alongside model names

## Benefits
- **Transparency**: Users can see exactly which model was used to evaluate/grade responses
- **Multi-provider clarity**: In multi-model tests, users can easily identify which provider each model uses
- **Better documentation**: Test reports are now more informative and self-documenting

## Testing
- Verified backward compatibility (works when evaluator info is not provided)
- All pre-commit hooks passed

## Screenshots/Examples
For multi-model tests, the report now shows:
```
Evaluator: google/gemini-2.5-flash (openrouter)

Multi-Model Comparison: 6 Models × 3 Modes

Claude 3.5 Sonnet        Gemini 2.5 Flash
(openrouter)             (openrouter)
🍦 Vanilla: 42.3%        🍦 Vanilla: 38.5%
🌐 Web: 53.8%            🌐 Web: 46.2%
🔧 MARRVEL: 96.2%        🔧 MARRVEL: 92.3%
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)