### PR TITLE
Fix: Use consistent evaluator model for all evaluations

### DIFF
--- a/mcp_llm_test/models_config.yaml
+++ b/mcp_llm_test/models_config.yaml
@@ -98,3 +98,11 @@ config:
 
   # Whether to cache results per model
   use_cache: true
+
+  # Evaluator model configuration (used for grading/classifying test responses)
+  # This model evaluates all test responses for consistent comparison across models
+  # If not specified, falls back to environment variables EVALUATION_MODEL and EVALUATION_PROVIDER
+  # or defaults to google/gemini-2.5-pro via openrouter
+  evaluator:
+    provider: "openrouter"
+    model: "google/gemini-2.5-pro"


### PR DESCRIPTION
## Summary
This PR implements proper evaluator separation using `EVALUATION_MODEL` and `EVALUATION_PROVIDER` configuration, ensuring all tested models are graded by a single consistent evaluator for fair comparison.

## Problem
Previously, each model being tested would evaluate its own responses, leading to inconsistent grading across models in multi-model mode:
- Model A generates response → Model A evaluates it
- Model B generates response → Model B evaluates it  
- Model C generates response → Model C evaluates it

This creates biased and inconsistent evaluations because different models have different evaluation criteria.

## Solution
Implemented dedicated evaluator configuration that is separate from the models being tested:

### 1. Environment Variable Support
- `EVALUATION_MODEL`: Specify the model ID for evaluation (e.g., `google/gemini-2.5-pro`)
- `EVALUATION_PROVIDER`: Specify the provider (e.g., `openrouter`, `openai`, `bedrock`, `ollama`)

Example:
```bash
export EVALUATION_MODEL="google/gemini-2.5-pro"
export EVALUATION_PROVIDER="openrouter"
python mcp_llm_test/evaluate_mcp.py --multi-model
```

### 2. YAML Configuration Support  
Added `evaluator` section to `models_config.yaml`:
```yaml
config:
  evaluator:
    provider: "openrouter"
    model: "google/gemini-2.5-pro"
```

### 3. Configuration Priority
1. YAML config file (`config.evaluator`)
2. Environment variables (`EVALUATION_MODEL`, `EVALUATION_PROVIDER`)
3. Default: `google/gemini-2.5-pro` via `openrouter`

### 4. Implementation Details
- Created separate `llm_evaluator` instance initialized from evaluator config
- Updated `evaluate_response()` to always use `llm_evaluator` (not the model being tested)
- Updated all HTML report calls to pass `evaluator_model`/`evaluator_provider`
- Added evaluator display in configuration output: `📊 Evaluator: openrouter / google/gemini-2.5-pro`

## Changes
- `mcp_llm_test/evaluate_mcp.py`:
  - Import `get_evaluation_model_config` from `config.llm_config`
  - Add `llm_evaluator` global variable
  - Update `evaluate_response()` to use `llm_evaluator`
  - Initialize `llm_evaluator` in `main()` from evaluator config
  - Update `load_models_config()` to return evaluator config from YAML
  - Apply YAML evaluator config in multi-model mode with validation
  - Update all `generate_html_report()` calls to use evaluator variables
  - Display evaluator configuration in output
- `mcp_llm_test/models_config.yaml`:
  - Add `config.evaluator` section with provider and model fields

## Testing
- ✅ All existing tests pass (`pytest tests/test_evaluate_mcp_subset.py`)
- ✅ Code formatted with black
- ✅ Pre-commit hooks pass

## Impact
- **Fair Comparison**: All models now graded by same consistent evaluator
- **Flexible Configuration**: Support for env vars and YAML config
- **Clear Reporting**: Evaluator model/provider displayed in HTML reports
- **Backward Compatible**: Defaults maintain existing behavior

## Documentation
The evaluator configuration is now:
1. Displayed when running evaluations: `📊 Evaluator: openrouter / google/gemini-2.5-pro`
2. Included in HTML evaluation reports
3. Documented in YAML config file with comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)