### PR TITLE
Fix missing N/A button for skipped items

### DIFF
--- a/assets/evaluation_report_template.html
+++ b/assets/evaluation_report_template.html
@@ -306,9 +306,13 @@ Template variables: success_rate, successful_tests, total_tests, results (list o
                             {% for model_id, model_data in result.models.items() %}
                             <!-- Vanilla -->
                             <td class="px-2 py-3 text-center bg-yellow-50 bg-opacity-30 border-l-2 border-gray-400">
+                                {% if model_data.vanilla.is_na %}
+                                <span class="px-3 py-1 rounded-full text-xs font-semibold bg-gray-200 text-gray-700">N/A</span>
+                                {% else %}
                                 <button onclick="showModal('modal-{{ result.idx }}-{{ model_id|replace('/', '_')|replace('.', '_') }}-vanilla')" onmouseenter="showTooltip(event, &quot;{{ model_data.vanilla.classification | replace('\n', ' ') | replace('\r', ' ') | replace('"', '&quot;') | escape }}&quot;)" onmouseleave="hideTooltip()" class="px-3 py-1 rounded-full text-xs font-semibold {% if model_data.vanilla.is_yes %}bg-green-100 text-green-800 hover:bg-green-200{% else %}bg-red-100 text-red-800 hover:bg-red-200{% endif %} transition-colors">
                                     {{ "YES" if model_data.vanilla.is_yes else "NO" }}
                                 </button>
+                                {% endif %}
                             </td>
                             <!-- Web -->
                             <td class="px-2 py-3 text-center bg-blue-50 bg-opacity-30">
@@ -336,9 +340,16 @@ Template variables: success_rate, successful_tests, total_tests, results (list o
                                     <h3 class="text-lg font-semibold text-gray-900">{{ model_data.name }} - 🍦 Vanilla Mode</h3>
                                     <button onclick="closeModal('{{ result.idx }}-{{ model_id|replace('/', '_')|replace('.', '_') }}-vanilla')" class="text-gray-400 hover:text-gray-600 text-2xl font-bold">&times;</button>
                                 </div>
+                                {% if model_data.vanilla.is_na %}
+                                <div class="p-4 bg-gray-100 rounded text-center">
+                                    <p class="text-lg font-semibold text-gray-700">N/A</p>
+                                    <p class="text-gray-600 mt-2">{{ model_data.vanilla.na_reason }}</p>
+                                </div>
+                                {% else %}
                                 <div class="max-h-96 overflow-y-auto">
                                     <pre id="json-content-{{ result.idx }}-{{ model_id|replace('/', '_')|replace('.', '_') }}-vanilla" class="p-4 bg-gray-900 text-green-400 rounded text-xs overflow-x-auto whitespace-pre">{{ model_data.vanilla.conversation | tojson_pretty }}</pre>
                                 </div>
+                                {% endif %}
                                 <div class="mt-4 flex justify-end gap-2">
                                     <button id="copy-btn-{{ result.idx }}-{{ model_id|replace('/', '_')|replace('.', '_') }}-vanilla" onclick="copyToClipboard('{{ result.idx }}-{{ model_id|replace('/', '_')|replace('.', '_') }}-vanilla')" class="inline-flex items-center gap-x-2 px-4 py-2 bg-gray-600 text-white text-sm font-medium rounded-md hover:bg-gray-700">
                                         Copy JSON

--- a/mcp_llm_test/evaluate_mcp.py
+++ b/mcp_llm_test/evaluate_mcp.py
@@ -849,7 +849,10 @@ def generate_html_report(
                 web_classification = model_data["web"].get("classification", "").lower()
                 tool_classification = model_data["tool"]["classification"].lower()
 
-                if re.search(r"\byes\b", vanilla_classification):
+                # Skip counting N/A vanilla results
+                if model_data["vanilla"].get("status") != "N/A" and re.search(
+                    r"\byes\b", vanilla_classification
+                ):
                     models_stats[model_id]["vanilla_success"] += 1
                 # Skip counting N/A web results
                 if model_data["web"].get("status") != "N/A" and re.search(
@@ -993,6 +996,8 @@ def generate_html_report(
                         "tokens_used": vanilla_res.get("tokens_used", 0),
                         "tool_calls": vanilla_res.get("tool_calls", []),
                         "conversation": vanilla_conversation,
+                        "is_na": vanilla_res.get("status") == "N/A",
+                        "na_reason": vanilla_res.get("reason", ""),
                     },
                     "web": {
                         "response": web_res.get("response", "N/A"),


### PR DESCRIPTION
When vanilla mode is skipped for certain models (via skip_vanilla option), the evaluation report now properly displays "N/A" instead of YES/NO buttons.

Changes:
- Add is_na and na_reason fields to vanilla results (similar to web mode)
- Update statistics calculation to skip N/A vanilla results
- Update HTML template to show N/A badge for skipped vanilla tests
- Update modal to display N/A reason when vanilla mode is skipped