### PR TITLE
Add total running time display to JSON window

### DIFF
--- a/assets/evaluation_report_template.html
+++ b/assets/evaluation_report_template.html
@@ -171,6 +171,23 @@ Template variables: success_rate, successful_tests, total_tests, results (list o
                 </div>
                 {% endif %}
 
+                <!-- Total Running Time -->
+                {% if total_duration %}
+                <div class="mt-3 bg-white bg-opacity-10 rounded px-3 py-1.5 inline-block">
+                    <p class="text-blue-100 text-xs">
+                        <span class="font-semibold">⏱️ Total Running Time:</span>
+                        {% if total_duration >= 3600 %}
+                            {{ "%.0f"|format(total_duration // 3600) }}h {{ "%.0f"|format((total_duration % 3600) // 60) }}m {{ "%.1f"|format(total_duration % 60) }}s
+                        {% elif total_duration >= 60 %}
+                            {{ "%.0f"|format(total_duration // 60) }}m {{ "%.1f"|format(total_duration % 60) }}s
+                        {% else %}
+                            {{ "%.1f"|format(total_duration) }}s
+                        {% endif %}
+                        ({{ "%.2f"|format(total_duration) }}s total)
+                    </p>
+                </div>
+                {% endif %}
+
                 <!-- Success Rate Summary -->
                 {% if multi_model %}
                 <div class="mt-6 bg-white bg-opacity-20 rounded-lg p-4 backdrop-blur-sm">

--- a/mcp_llm_test/evaluate_mcp.py
+++ b/mcp_llm_test/evaluate_mcp.py
@@ -804,6 +804,7 @@ def generate_html_report(
     multi_model: bool = False,
     evaluator_model: str | None = None,
     evaluator_provider: str | None = None,
+    total_duration: float | None = None,
 ) -> str:
     """Generate HTML report with modal popups, reordered columns, and success rate summary.
 
@@ -814,6 +815,7 @@ def generate_html_report(
         multi_model: If True, results contain multiple models across all three modes
         evaluator_model: Model ID used for evaluation/grading
         evaluator_provider: Provider used for evaluation model
+        total_duration: Total execution time in seconds
 
     Returns:
         Path to generated HTML file
@@ -1166,6 +1168,7 @@ def generate_html_report(
             results=enriched_results,
             evaluator_model=evaluator_model,
             evaluator_provider=evaluator_provider,
+            total_duration=total_duration,
         )
     elif tri_mode:
         html_content = template.render(
@@ -1180,6 +1183,7 @@ def generate_html_report(
             results=enriched_results,
             evaluator_model=evaluator_model,
             evaluator_provider=evaluator_provider,
+            total_duration=total_duration,
         )
     elif dual_mode:
         html_content = template.render(
@@ -1192,6 +1196,7 @@ def generate_html_report(
             results=enriched_results,
             evaluator_model=evaluator_model,
             evaluator_provider=evaluator_provider,
+            total_duration=total_duration,
         )
     else:
         html_content = template.render(
@@ -1202,6 +1207,7 @@ def generate_html_report(
             results=enriched_results,
             evaluator_model=evaluator_model,
             evaluator_provider=evaluator_provider,
+            total_duration=total_duration,
         )
 
     temp_html.write(html_content)
@@ -1434,6 +1440,11 @@ async def main():
     """
     Main function to run the evaluation concurrently.
     """
+    import time
+
+    # Track total execution time
+    start_time = time.time()
+
     global llm, llm_web, llm_evaluator, OPENROUTER_API_KEY
 
     # Parse command-line arguments
@@ -2155,11 +2166,13 @@ async def main():
 
         # Generate HTML report with multi-model comparison
         try:
+            total_duration = time.time() - start_time
             html_path = generate_html_report(
                 combined_results,
                 multi_model=True,
                 evaluator_model=evaluator_model,
                 evaluator_provider=evaluator_provider,
+                total_duration=total_duration,
             )
             open_in_browser(html_path)
         except Exception as e:
@@ -2246,11 +2259,13 @@ async def main():
 
         # Generate HTML report with 3-way comparison
         try:
+            total_duration = time.time() - start_time
             html_path = generate_html_report(
                 combined_results,
                 tri_mode=True,
                 evaluator_model=evaluator_model,
                 evaluator_provider=evaluator_provider,
+                total_duration=total_duration,
             )
             open_in_browser(html_path)
         except Exception as e:
@@ -2313,11 +2328,13 @@ async def main():
 
         # Generate HTML report with dual-mode results
         try:
+            total_duration = time.time() - start_time
             html_path = generate_html_report(
                 combined_results,
                 dual_mode=True,
                 evaluator_model=evaluator_model,
                 evaluator_provider=evaluator_provider,
+                total_duration=total_duration,
             )
             open_in_browser(html_path)
         except Exception as e:
@@ -2357,10 +2374,12 @@ async def main():
 
         # Generate HTML report and open in browser
         try:
+            total_duration = time.time() - start_time
             html_path = generate_html_report(
                 ordered_results,
                 evaluator_model=evaluator_model,
                 evaluator_provider=evaluator_provider,
+                total_duration=total_duration,
             )
             open_in_browser(html_path)
         except Exception as e:


### PR DESCRIPTION
- Track total execution time from start of main() to report generation
- Display running time prominently at top of HTML report header
- Format as human-readable (hours/minutes/seconds) with exact total
- Helps identify appropriate timeout values for test execution
- Added total_duration parameter to generate_html_report() function