### PR TITLE
Add timeout and retry configuration to prevent hanging

### DIFF
--- a/config/llm_providers.py
+++ b/config/llm_providers.py
@@ -343,6 +343,8 @@ def create_llm_instance(
         openai_kwargs: Dict[str, Any] = {
             "model": effective_model_id,
             "temperature": temperature,
+            "timeout": 300,  # 5 minute timeout to prevent hanging
+            "max_retries": 2,  # Reduce retries to fail faster
             **kwargs,
         }
 

--- a/mcp_llm_test/local_api_config.yaml
+++ b/mcp_llm_test/local_api_config.yaml
@@ -1,0 +1,21 @@
+# Temporary configuration for testing local OpenAI-compatible API
+# Usage: python evaluate_mcp.py --subset "1" --models-config local_api_config.yaml
+
+models:
+  - name: "Local GPT OSS 20B"
+    id: "openai/gpt-oss-20b"
+    provider: "openai"
+    enabled: true
+    skip_vanilla: false
+    skip_web_search: true
+    description: "Local OpenAI-compatible API at localhost:8031"
+
+config:
+  only_enabled: true
+  timeout: 60
+  use_cache: false
+
+  # Evaluator also uses the same local API
+  evaluator:
+    provider: "openai"
+    model: "openai/gpt-oss-20b"


### PR DESCRIPTION
## Changes
- Add 5-minute timeout to ChatOpenAI instances to prevent indefinite hanging
- Reduce max_retries to 2 for faster failure detection  
- Add local_api_config.yaml for testing with local OpenAI-compatible APIs

## Problem
When testing with local OpenAI-compatible APIs (e.g., at localhost:8013), if the server hangs or doesn't respond, the client would wait indefinitely without any timeout, requiring manual intervention to stop.

## Solution
Configure ChatOpenAI with explicit timeout (300s) and reduced retries (2) to fail gracefully instead of hanging forever.

## Testing
Tested with local API at localhost:8013 with openai/gpt-oss-20b model.