### PR TITLE
feat: Implement run resume functionality, test case snapshotting with deterministic UUIDs, and enhanced cache-driven retry for failed evaluations.

### DIFF
--- a/mcp_llm_test/evaluation_modules/cache.py
+++ b/mcp_llm_test/evaluation_modules/cache.py
@@ -15,15 +15,17 @@ CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
 
 def get_cache_path(
-    test_case_name: str,
+    run_id: str,
+    test_uuid: str,
     vanilla_mode: bool = False,
     web_mode: bool = False,
     model_id: str | None = None,
 ) -> Path:
-    """Get the cache file path for a test case.
+    """Get the cache file path for a test case using its UUID.
 
     Args:
-        test_case_name: Name of the test case
+        run_id: Unique identifier for the run (used as directory name)
+        test_uuid: Unique identifier for the test case
         vanilla_mode: If True, append '_vanilla' to distinguish from tool-enabled cache
         web_mode: If True, append '_web' to distinguish from vanilla cache
         model_id: Model identifier (e.g., "google/gemini-2.5-flash"). If provided, cache is model-specific.
@@ -31,9 +33,9 @@ def get_cache_path(
     Returns:
         Path to cache file
     """
-    # Use sanitized test case name for filename
-    safe_name = "".join(c if c.isalnum() or c in (" ", "-", "_") else "_" for c in test_case_name)
-    safe_name = safe_name.strip().replace(" ", "_")
+    # Create run-specific directory
+    run_dir = CACHE_DIR / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
 
     # Add model identifier if provided (sanitize it too)
     if model_id:
@@ -50,11 +52,13 @@ def get_cache_path(
     else:
         mode_suffix = ""
 
-    return CACHE_DIR / f"{safe_name}{model_suffix}{mode_suffix}.pkl"
+    # Use UUID for filename
+    return run_dir / f"{test_uuid}{model_suffix}{mode_suffix}.pkl"
 
 
 def load_cached_result(
-    test_case_name: str,
+    run_id: str,
+    test_uuid: str,
     vanilla_mode: bool = False,
     web_mode: bool = False,
     model_id: str | None = None,
@@ -62,7 +66,8 @@ def load_cached_result(
     """Load cached result for a test case if it exists.
 
     Args:
-        test_case_name: Name of the test case
+        run_id: Unique identifier for the run
+        test_uuid: Unique identifier for the test case
         vanilla_mode: If True, load from vanilla cache
         web_mode: If True, load from web cache
         model_id: Model identifier for model-specific cache
@@ -70,19 +75,20 @@ def load_cached_result(
     Returns:
         Cached result or None if not found
     """
-    cache_path = get_cache_path(test_case_name, vanilla_mode, web_mode, model_id)
+    cache_path = get_cache_path(run_id, test_uuid, vanilla_mode, web_mode, model_id)
     if cache_path.exists():
         try:
             with open(cache_path, "rb") as f:
                 return pickle.load(f)
         except Exception as e:
-            print(f"Warning: Failed to load cache for {test_case_name}: {e}")
+            print(f"Warning: Failed to load cache for {test_uuid}: {e}")
             return None
     return None
 
 
 def save_cached_result(
-    test_case_name: str,
+    run_id: str,
+    test_uuid: str,
     result: Dict[str, Any],
     vanilla_mode: bool = False,
     web_mode: bool = False,
@@ -91,26 +97,45 @@ def save_cached_result(
     """Save result to cache.
 
     Args:
-        test_case_name: Name of the test case
         result: Test result to cache
+        run_id: Unique identifier for the run
+        test_uuid: Unique identifier for the test case
         vanilla_mode: If True, save to vanilla cache
         web_mode: If True, save to web cache
         model_id: Model identifier for model-specific cache
     """
-    cache_path = get_cache_path(test_case_name, vanilla_mode, web_mode, model_id)
+
+    cache_path = get_cache_path(run_id, test_uuid, vanilla_mode, web_mode, model_id)
     try:
         with open(cache_path, "wb") as f:
             pickle.dump(result, f)
     except Exception as e:
-        print(f"Warning: Failed to save cache for {test_case_name}: {e}")
+        print(f"Warning: Failed to save cache for {test_uuid}: {e}")
 
 
-def clear_cache():
-    """Clear all cached results."""
-    if CACHE_DIR.exists():
-        for cache_file in CACHE_DIR.glob("*.pkl"):
+def clear_cache(run_id: str | None = None):
+    """Clear cached results.
+
+    Args:
+        run_id: If provided, clear only that run's cache. Otherwise clear all.
+    """
+    if run_id:
+        target_dir = CACHE_DIR / run_id
+        if target_dir.exists():
+            import shutil
+
             try:
-                cache_file.unlink()
+                shutil.rmtree(target_dir)
+                print(f"✅ Cache cleared for run: {run_id}")
             except Exception as e:
-                print(f"Warning: Failed to delete {cache_file}: {e}")
-        print(f"✅ Cache cleared: {CACHE_DIR}")
+                print(f"Warning: Failed to delete {target_dir}: {e}")
+    else:
+        if CACHE_DIR.exists():
+            import shutil
+
+            try:
+                shutil.rmtree(CACHE_DIR)
+                CACHE_DIR.mkdir(parents=True, exist_ok=True)
+                print(f"✅ All caches cleared: {CACHE_DIR}")
+            except Exception as e:
+                print(f"Warning: Failed to delete {CACHE_DIR}: {e}")

--- a/mcp_llm_test/evaluation_modules/cli.py
+++ b/mcp_llm_test/evaluation_modules/cli.py
@@ -141,6 +141,19 @@ Cache Behavior:
     )
 
     parser.add_argument(
+        "--resume",
+        type=str,
+        metavar="RUN_ID",
+        help="Resume a previous run by providing its Run ID. Skips successfully completed tests.",
+    )
+
+    parser.add_argument(
+        "--retry-failed",
+        action="store_true",
+        help="Re-run failed tests when resuming a run. If not specified, failed tests are skipped (loaded from cache).",
+    )
+
+    parser.add_argument(
         "--subset",
         type=str,
         metavar="INDICES",

--- a/modify_pkl.py
+++ b/modify_pkl.py
@@ -1,0 +1,20 @@
+import pickle
+from pathlib import Path
+import sys
+
+
+def modify_pkl(path):
+    p = Path(path).expanduser()
+    with open(p, "rb") as f:
+        data = pickle.load(f)
+
+    print(f"Original classification: {data.get('classification')}")
+    data["classification"] = "no - simulated failure"
+
+    with open(p, "wb") as f:
+        pickle.dump(data, f)
+    print(f"Modified classification: {data.get('classification')}")
+
+
+if __name__ == "__main__":
+    modify_pkl(sys.argv[1])


### PR DESCRIPTION
This pull request introduces a robust run management and caching system to the MCP LLM evaluation framework. The main changes include the addition of unique run IDs, deterministic test case UUIDs, improved cache handling per run and test case, and new CLI options for resuming runs and selectively retrying failed tests. These changes make test execution more reproducible, allow for precise resumption of previous runs, and improve cache reliability and cleanup.

**Run and Cache Management Improvements**
* Introduced unique run IDs (`run_id`) for each evaluation session, generated via UUID, and deterministic test case UUIDs based on test case content. Test case snapshots are saved per run for reproducibility and resumption. (`mcp_llm_test/evaluate_mcp.py`) [[1]](diffhunk://#diff-70d4d8f9237cc18471e045596fd20d869be0c88960d1387ed316f80f79bdb501R112-R122) [[2]](diffhunk://#diff-70d4d8f9237cc18471e045596fd20d869be0c88960d1387ed316f80f79bdb501L267-R313)
* Refactored cache system to store results per run and test case UUID, enabling fine-grained cache control and cleanup. Added `clear_cache(run_id)` to selectively clear cache for a specific run or all runs. (`mcp_llm_test/evaluation_modules/cache.py`) [[1]](diffhunk://#diff-059c72cf57e70d7617c9c9acd9a6afea502e2c77c3436fa58e75a66fb62a1b3cL18-R38) [[2]](diffhunk://#diff-059c72cf57e70d7617c9c9acd9a6afea502e2c77c3436fa58e75a66fb62a1b3cL94-R141)

**Test Execution and Retry Logic**
* Updated test execution to pass `run_id` and test case UUID to all cache operations, ensuring correct cache usage and isolation per run. (`mcp_llm_test/evaluate_mcp.py`, `mcp_llm_test/evaluation_modules/test_execution.py`) [[1]](diffhunk://#diff-70d4d8f9237cc18471e045596fd20d869be0c88960d1387ed316f80f79bdb501R462-R465) [[2]](diffhunk://#diff-f41187b1c7dc1280203703bdf21ccbc6a645d1071e0431496bcbb10755208b8fR23-R26)
* Enhanced retry logic: when resuming, failed tests can be selectively retried with `--retry-failed`, and error cases are always retried. Successful cached results are reused, while failures are only retried if requested. (`mcp_llm_test/evaluation_modules/test_execution.py`)

**CLI Enhancements**
* Added new CLI options: `--resume RUN_ID` to resume a previous run, and `--retry-failed` to re-run only failed tests when resuming. (`mcp_llm_test/evaluation_modules/cli.py`)

**General Codebase Improvements**
* Improved cache usage defaults and run directory management for better reproducibility and error handling. (`mcp_llm_test/evaluate_mcp.py`)
* Updated all relevant function signatures and usages to support new run and cache management logic. (`mcp_llm_test/evaluate_mcp.py`, `mcp_llm_test/evaluation_modules/test_execution.py`) [[1]](diffhunk://#diff-70d4d8f9237cc18471e045596fd20d869be0c88960d1387ed316f80f79bdb501R462-R465) [[2]](diffhunk://#diff-f41187b1c7dc1280203703bdf21ccbc6a645d1071e0431496bcbb10755208b8fR42-R46)

These changes significantly improve the reliability and usability of the evaluation framework, especially for long-running or interrupted test sessions.