### PR TITLE
Add Create GitHub Issue button to evaluation report modals

### DIFF
--- a/assets/evaluation_report_template.html
+++ b/assets/evaluation_report_template.html
@@ -274,7 +274,14 @@ Template variables: success_rate, successful_tests, total_tests, results (list o
         }
 
         // Open GitHub issue creation page with pre-filled content
-        function createGitHubIssue(id, question, expected, mode) {
+        function createGitHubIssue(button) {
+            const id = button.getAttribute('data-id');
+            const question = button.getAttribute('data-question');
+            const expected = button.getAttribute('data-expected');
+            const mode = button.getAttribute('data-mode');
+            const model = button.getAttribute('data-model');
+            const classification = button.getAttribute('data-classification');
+
             const preElement = document.getElementById('json-content-' + id);
             const jsonContent = preElement ? preElement.textContent : '';
 
@@ -288,6 +295,9 @@ Template variables: success_rate, successful_tests, total_tests, results (list o
             // Format as GitHub Issue markdown
             const body = `## Test Case Failure Report
 
+### Testing Model
+${model}
+
 ### Question
 ${question}
 
@@ -296,6 +306,9 @@ ${expected}
 
 ### Mode
 ${modeLabel}
+
+### Evaluation Result
+${classification}
 
 ### Full Conversation JSON
 \`\`\`json
@@ -547,7 +560,7 @@ ${jsonContent}
                                     <button id="copy-btn-{{ result.idx }}-{{ model_id|replace('/', '_')|replace('.', '_') }}-vanilla" onclick="copyToClipboard('{{ result.idx }}-{{ model_id|replace('/', '_')|replace('.', '_') }}-vanilla')" class="inline-flex items-center gap-x-2 px-4 py-2 bg-gray-600 text-white text-sm font-medium rounded-md hover:bg-gray-700">
                                         Copy JSON
                                     </button>
-                                    <button onclick="createGitHubIssue('{{ result.idx }}-{{ model_id|replace('/', '_')|replace('.', '_') }}-vanilla', `{{ result.question | replace('`', '\\`') | replace('\n', ' ') }}`, `{{ result.expected | replace('`', '\\`') | replace('\n', ' ') }}`, 'vanilla')" class="inline-flex items-center gap-x-2 px-4 py-2 bg-purple-600 text-white text-sm font-medium rounded-md hover:bg-purple-700">
+                                    <button onclick="createGitHubIssue(this)" data-id="{{ result.idx }}-{{ model_id|replace('/', '_')|replace('.', '_') }}-vanilla" data-question="{{ result.question | e }}" data-expected="{{ result.expected | e }}" data-mode="vanilla" data-model="{{ model_data.name | e }}" data-classification="{{ model_data.vanilla.classification | e }}" class="inline-flex items-center gap-x-2 px-4 py-2 bg-purple-600 text-white text-sm font-medium rounded-md hover:bg-purple-700">
                                         <svg class="-ml-0.5 h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
                                             <path fill-rule="evenodd" d="M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z" clip-rule="evenodd" />
                                         </svg>
@@ -580,7 +593,7 @@ ${jsonContent}
                                     <button id="copy-btn-{{ result.idx }}-{{ model_id|replace('/', '_')|replace('.', '_') }}-web" onclick="copyToClipboard('{{ result.idx }}-{{ model_id|replace('/', '_')|replace('.', '_') }}-web')" class="inline-flex items-center gap-x-2 px-4 py-2 bg-gray-600 text-white text-sm font-medium rounded-md hover:bg-gray-700">
                                         Copy JSON
                                     </button>
-                                    <button onclick="createGitHubIssue('{{ result.idx }}-{{ model_id|replace('/', '_')|replace('.', '_') }}-web', `{{ result.question | replace('`', '\\`') | replace('\n', ' ') }}`, `{{ result.expected | replace('`', '\\`') | replace('\n', ' ') }}`, 'web')" class="inline-flex items-center gap-x-2 px-4 py-2 bg-purple-600 text-white text-sm font-medium rounded-md hover:bg-purple-700">
+                                    <button onclick="createGitHubIssue(this)" data-id="{{ result.idx }}-{{ model_id|replace('/', '_')|replace('.', '_') }}-web" data-question="{{ result.question | e }}" data-expected="{{ result.expected | e }}" data-mode="web" data-model="{{ model_data.name | e }}" data-classification="{{ model_data.web.classification | e }}" class="inline-flex items-center gap-x-2 px-4 py-2 bg-purple-600 text-white text-sm font-medium rounded-md hover:bg-purple-700">
                                         <svg class="-ml-0.5 h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
                                             <path fill-rule="evenodd" d="M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z" clip-rule="evenodd" />
                                         </svg>
@@ -606,7 +619,7 @@ ${jsonContent}
                                     <button id="copy-btn-{{ result.idx }}-{{ model_id|replace('/', '_')|replace('.', '_') }}-tool" onclick="copyToClipboard('{{ result.idx }}-{{ model_id|replace('/', '_')|replace('.', '_') }}-tool')" class="inline-flex items-center gap-x-2 px-4 py-2 bg-gray-600 text-white text-sm font-medium rounded-md hover:bg-gray-700">
                                         Copy JSON
                                     </button>
-                                    <button onclick="createGitHubIssue('{{ result.idx }}-{{ model_id|replace('/', '_')|replace('.', '_') }}-tool', `{{ result.question | replace('`', '\\`') | replace('\n', ' ') }}`, `{{ result.expected | replace('`', '\\`') | replace('\n', ' ') }}`, 'tool')" class="inline-flex items-center gap-x-2 px-4 py-2 bg-purple-600 text-white text-sm font-medium rounded-md hover:bg-purple-700">
+                                    <button onclick="createGitHubIssue(this)" data-id="{{ result.idx }}-{{ model_id|replace('/', '_')|replace('.', '_') }}-tool" data-question="{{ result.question | e }}" data-expected="{{ result.expected | e }}" data-mode="tool" data-model="{{ model_data.name | e }}" data-classification="{{ model_data.tool.classification | e }}" class="inline-flex items-center gap-x-2 px-4 py-2 bg-purple-600 text-white text-sm font-medium rounded-md hover:bg-purple-700">
                                         <svg class="-ml-0.5 h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
                                             <path fill-rule="evenodd" d="M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z" clip-rule="evenodd" />
                                         </svg>
@@ -796,7 +809,7 @@ ${jsonContent}
                                         </svg>
                                         Copy JSON
                                     </button>
-                                    <button onclick="createGitHubIssue('vanilla-{{ result.idx }}', `{{ result.question | replace('`', '\\`') | replace('\n', ' ') }}`, `{{ result.expected | replace('`', '\\`') | replace('\n', ' ') }}`, 'vanilla')" class="inline-flex items-center gap-x-2 px-4 py-2 bg-purple-600 text-white text-sm font-medium rounded-md hover:bg-purple-700">
+                                    <button onclick="createGitHubIssue(this)" data-id="vanilla-{{ result.idx }}" data-question="{{ result.question | e }}" data-expected="{{ result.expected | e }}" data-mode="vanilla" data-model="{{ tested_model | default('Unknown') | e }}" data-classification="{{ result.vanilla.classification | e }}" class="inline-flex items-center gap-x-2 px-4 py-2 bg-purple-600 text-white text-sm font-medium rounded-md hover:bg-purple-700">
                                         <svg class="-ml-0.5 h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
                                             <path fill-rule="evenodd" d="M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z" clip-rule="evenodd" />
                                         </svg>
@@ -826,7 +839,7 @@ ${jsonContent}
                                         </svg>
                                         Copy JSON
                                     </button>
-                                    <button onclick="createGitHubIssue('web-{{ result.idx }}', `{{ result.question | replace('`', '\\`') | replace('\n', ' ') }}`, `{{ result.expected | replace('`', '\\`') | replace('\n', ' ') }}`, 'web')" class="inline-flex items-center gap-x-2 px-4 py-2 bg-purple-600 text-white text-sm font-medium rounded-md hover:bg-purple-700">
+                                    <button onclick="createGitHubIssue(this)" data-id="web-{{ result.idx }}" data-question="{{ result.question | e }}" data-expected="{{ result.expected | e }}" data-mode="web" data-model="{{ tested_model | default('Unknown') | e }}" data-classification="{{ result.web.classification | e }}" class="inline-flex items-center gap-x-2 px-4 py-2 bg-purple-600 text-white text-sm font-medium rounded-md hover:bg-purple-700">
                                         <svg class="-ml-0.5 h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
                                             <path fill-rule="evenodd" d="M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z" clip-rule="evenodd" />
                                         </svg>
@@ -856,7 +869,7 @@ ${jsonContent}
                                         </svg>
                                         Copy JSON
                                     </button>
-                                    <button onclick="createGitHubIssue('tool-{{ result.idx }}', `{{ result.question | replace('`', '\\`') | replace('\n', ' ') }}`, `{{ result.expected | replace('`', '\\`') | replace('\n', ' ') }}`, 'tool')" class="inline-flex items-center gap-x-2 px-4 py-2 bg-purple-600 text-white text-sm font-medium rounded-md hover:bg-purple-700">
+                                    <button onclick="createGitHubIssue(this)" data-id="tool-{{ result.idx }}" data-question="{{ result.question | e }}" data-expected="{{ result.expected | e }}" data-mode="tool" data-model="{{ tested_model | default('Unknown') | e }}" data-classification="{{ result.tool.classification | e }}" class="inline-flex items-center gap-x-2 px-4 py-2 bg-purple-600 text-white text-sm font-medium rounded-md hover:bg-purple-700">
                                         <svg class="-ml-0.5 h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
                                             <path fill-rule="evenodd" d="M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z" clip-rule="evenodd" />
                                         </svg>
@@ -987,7 +1000,7 @@ ${jsonContent}
                                         </svg>
                                         Copy JSON
                                     </button>
-                                    <button onclick="createGitHubIssue('vanilla-{{ result.idx }}', `{{ result.question | replace('`', '\\`') | replace('\n', ' ') }}`, `{{ result.expected | replace('`', '\\`') | replace('\n', ' ') }}`, 'vanilla')" class="inline-flex items-center gap-x-2 px-4 py-2 bg-purple-600 text-white text-sm font-medium rounded-md hover:bg-purple-700">
+                                    <button onclick="createGitHubIssue(this)" data-id="vanilla-{{ result.idx }}" data-question="{{ result.question | e }}" data-expected="{{ result.expected | e }}" data-mode="vanilla" data-model="{{ tested_model | default('Unknown') | e }}" data-classification="{{ result.vanilla.classification | e }}" class="inline-flex items-center gap-x-2 px-4 py-2 bg-purple-600 text-white text-sm font-medium rounded-md hover:bg-purple-700">
                                         <svg class="-ml-0.5 h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
                                             <path fill-rule="evenodd" d="M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z" clip-rule="evenodd" />
                                         </svg>
@@ -1017,7 +1030,7 @@ ${jsonContent}
                                         </svg>
                                         Copy JSON
                                     </button>
-                                    <button onclick="createGitHubIssue('tool-{{ result.idx }}', `{{ result.question | replace('`', '\\`') | replace('\n', ' ') }}`, `{{ result.expected | replace('`', '\\`') | replace('\n', ' ') }}`, 'tool')" class="inline-flex items-center gap-x-2 px-4 py-2 bg-purple-600 text-white text-sm font-medium rounded-md hover:bg-purple-700">
+                                    <button onclick="createGitHubIssue(this)" data-id="tool-{{ result.idx }}" data-question="{{ result.question | e }}" data-expected="{{ result.expected | e }}" data-mode="tool" data-model="{{ tested_model | default('Unknown') | e }}" data-classification="{{ result.tool.classification | e }}" class="inline-flex items-center gap-x-2 px-4 py-2 bg-purple-600 text-white text-sm font-medium rounded-md hover:bg-purple-700">
                                         <svg class="-ml-0.5 h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
                                             <path fill-rule="evenodd" d="M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z" clip-rule="evenodd" />
                                         </svg>
@@ -1117,7 +1130,7 @@ ${jsonContent}
                                         </svg>
                                         Copy JSON
                                     </button>
-                                    <button onclick="createGitHubIssue({{ result.idx }}, `{{ result.question | replace('`', '\\`') | replace('\n', ' ') }}`, `{{ result.expected | replace('`', '\\`') | replace('\n', ' ') }}`, 'tool')" class="inline-flex items-center gap-x-2 px-4 py-2 bg-purple-600 text-white text-sm font-medium rounded-md hover:bg-purple-700">
+                                    <button onclick="createGitHubIssue(this)" data-id="{{ result.idx }}" data-question="{{ result.question | e }}" data-expected="{{ result.expected | e }}" data-mode="tool" data-model="{{ tested_model | default('Unknown') | e }}" data-classification="{{ result.classification | e }}" class="inline-flex items-center gap-x-2 px-4 py-2 bg-purple-600 text-white text-sm font-medium rounded-md hover:bg-purple-700">
                                         <svg class="-ml-0.5 h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
                                             <path fill-rule="evenodd" d="M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z" clip-rule="evenodd" />
                                         </svg>


### PR DESCRIPTION
## Summary
- Added `createGitHubIssue()` JavaScript function that opens GitHub's new issue page with pre-filled content including the test case question, expected answer, mode, and full conversation JSON in markdown format
- Added purple "Create GitHub Issue" button to all modal dialog types (single mode, dual mode, tri-mode, and multi-model)
- Issue body automatically formats test data with markdown headers and JSON code blocks
- Also fixed missing Copy JSON buttons and IDs in dual-mode modals

## Test plan
- [ ] Run evaluation with single mode and verify "Create GitHub Issue" button appears in modal
- [ ] Run evaluation with dual mode and verify buttons appear in both vanilla and tool modals
- [ ] Run evaluation with tri-mode and verify buttons appear in vanilla, web, and tool modals
- [ ] Click "Create GitHub Issue" button and verify it opens GitHub's new issue page with pre-filled content
- [ ] Verify the issue body contains properly formatted markdown with JSON code block

🤖 Generated with [Claude Code](https://claude.com/claude-code)