### PR TITLE
Prepare MARRVEL-MCP for PyPI and MCP Registry publishing

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,117 @@
+name: Publish to PyPI and MCP Registry
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-dist:
+    name: Build Distribution
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Verify release metadata versions
+        env:
+          RELEASE_VERSION: ${{ github.ref_name }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import pathlib
+          import tomllib
+
+          release = os.environ["RELEASE_VERSION"]
+          if release.startswith("v"):
+              release = release[1:]
+
+          pyproject = tomllib.loads(pathlib.Path("pyproject.toml").read_text())
+          server = json.loads(pathlib.Path("server.json").read_text())
+
+          package_version = pyproject["project"]["version"]
+          server_version = server["version"]
+          package_entry = server["packages"][0]
+          package_entry_version = package_entry["version"]
+
+          expected = release
+          versions = {
+              "pyproject.toml": package_version,
+              "server.json": server_version,
+              "server.json package": package_entry_version,
+          }
+
+          mismatches = [
+              f"{name}={value}"
+              for name, value in versions.items()
+              if value != expected
+          ]
+          if mismatches:
+              raise SystemExit(
+                  "Version mismatch for release "
+                  f"{expected}: " + ", ".join(mismatches)
+              )
+          PY
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade build
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Upload built distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-dist
+          path: dist/*
+
+  publish-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: build-dist
+    environment:
+      name: pypi
+      url: https://pypi.org/p/marrvel-mcp
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download built distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-dist
+          path: dist
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-mcp:
+    name: Publish to MCP Registry
+    runs-on: ubuntu-latest
+    needs: publish-pypi
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server to MCP Registry
+        run: ./mcp-publisher publish

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ mcp_llm_test/evaluate_mcp_new.py
 
 # Claude Code
 .claude/
+
+.webui_secret_key

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # MARRVEL-MCP
+<!-- mcp-name: io.github.hyunhwan-bcm/marrvel-mcp -->
 
 [![CI](https://github.com/hyunhwan-bcm/MARRVEL_MCP/actions/workflows/ci.yml/badge.svg)](https://github.com/hyunhwan-bcm/MARRVEL_MCP/actions/workflows/ci.yml)
 [![Pre-commit](https://github.com/hyunhwan-bcm/MARRVEL_MCP/actions/workflows/pre-commit.yml/badge.svg)](https://github.com/hyunhwan-bcm/MARRVEL_MCP/actions/workflows/pre-commit.yml)

--- a/marrvel_mcp/__init__.py
+++ b/marrvel_mcp/__init__.py
@@ -121,7 +121,7 @@ __all__ = [
 ]
 
 # Package metadata
-__version__ = "1.0.0"
+__version__ = "0.1.0"
 __author__ = "MARRVEL Team"
 __description__ = (
     "MARRVEL MCP server and agent components for genetics research with LLM tool calling"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,16 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "marrvel-mcp"
 version = "0.1.0"
 description = "MARRVEL MCP server providing 35+ tools for rare disease genetics research"
 requires-python = ">=3.12"
+readme = "README.md"
+authors = [
+    { name = "MARRVEL Team" },
+]
 dependencies = [
     # MCP server framework
     "fastmcp>=3.0.0b1",
@@ -32,6 +40,11 @@ eval = [
 
 [project.scripts]
 marrvel-mcp = "marrvel_mcp.server:main"
+
+[project.urls]
+Homepage = "https://github.com/hyunhwan-bcm/MARRVEL_MCP"
+Repository = "https://github.com/hyunhwan-bcm/MARRVEL_MCP"
+Issues = "https://github.com/hyunhwan-bcm/MARRVEL_MCP/issues"
 
 [dependency-groups]
 dev = [
@@ -70,3 +83,6 @@ asyncio_mode = "auto"
 markers = [
     "integration: marks tests as integration tests (may be slow)",
 ]
+
+[tool.setuptools.packages.find]
+include = ["marrvel_mcp*", "config*"]

--- a/server.json
+++ b/server.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.hyunhwan-bcm/marrvel-mcp",
+  "title": "MARRVEL-MCP",
+  "description": "MARRVEL MCP server providing 35+ tools for rare disease genetics research.",
+  "version": "0.1.0",
+  "repository": {
+    "url": "https://github.com/hyunhwan-bcm/MARRVEL_MCP",
+    "source": "github"
+  },
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "marrvel-mcp",
+      "version": "0.1.0",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add PyPI packaging metadata and align package versioning
- add MCP registry manifest and README mcp-name marker
- add GitHub Actions workflow to publish to PyPI and the MCP Registry

## Verification
- uv build
- validated server.json and README mcp-name marker
